### PR TITLE
Deserialize Message Before Handlers Iteration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mitz-it/websocket-client",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "WebSocket Client abstraction",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,12 +77,12 @@ class WebSocketClient {
   }
 
   private handleMessage(event: MessageEvent, handlers: MessageHandler<any>[]) {
+    const message = JSON.parse(event.data);
+
     for (let index = 0; index < handlers.length; index++) {
       const handler = handlers[index];
 
       const { assert, callback } = handler;
-
-      const message = JSON.parse(event.data);
 
       if (!assert(message)) continue;
 


### PR DESCRIPTION
The `handleMessage` method was deserializing the data from the `event` on every handler iteration, this is not necessary, since the received message won't change on each iteration.

Package update to version `1.4.1`